### PR TITLE
fix: SW TypeError

### DIFF
--- a/public/ServiceWorker.js
+++ b/public/ServiceWorker.js
@@ -117,6 +117,7 @@ this.addEventListener('activate', (event) => {
 const MAX_AGE = 60;
 
 this.addEventListener('fetch', (event) => {
+  if (!(event.request.url.indexOf('http') === 0)) return;
   event.respondWith(
     // ищем запрошенный ресурс среди закэшированных
     caches.match(event.request).then((cachedResponse) => {


### PR DESCRIPTION
Исправление ошибки serviceWorker.js:48 Uncaught (in promise) TypeError: Failed to execute 'put' on 'Cache': Request scheme 'chrome-extension' is unsupported code example
https://developer.mozilla.org/ru/docs/Web/API/Cache/put#examples
Из док.: Note: The promise will reject with a TypeError if the URL scheme is not http or https.